### PR TITLE
Update to compile with rust nightly v1.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpp"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Michael Layzell <michael@thelayzells.com>"]
 
 description = "Write C++ code inline in your rust code!"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The API and functionality of this compiler plugin is very experimental and unsta
 
 ## Usage
 
+Use the plugin
+
+```rust
+#![feature(plugin)]
+#![plugin(cpp)]
+```
+
 Import C++ header files
 
 ```rust

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -10,7 +10,7 @@ use std::ffi::OsString;
 use rustc_front::hir::Expr;
 use rustc_front::hir::Expr_::*;
 use syntax::ptr::P;
-use syntax::diagnostic;
+use syntax::errors;
 
 use rustc::lint::*;
 use rustc::session::search_paths::SearchPaths;
@@ -215,7 +215,7 @@ extern "C" {{{}}}
     unsafe {
         let sp = &cx.sess().opts.search_paths;
         let sp_mut: &mut SearchPaths = &mut *(sp as *const _ as *mut _);
-        sp_mut.add_path(&out_dir.to_str().unwrap(), diagnostic::ColorConfig::Never);
+        sp_mut.add_path(&out_dir.to_str().unwrap(), errors::ColorConfig::Never);
     }
 
     // I didn't want to write my own compiler driver-driver, so I'm using gcc.

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -5,7 +5,6 @@ use syntax::codemap::Span;
 use syntax::util::small_vector::SmallVector;
 use syntax::abi;
 use syntax::ast::*;
-use syntax::ast_util::empty_generics;
 use syntax::ext::base::{MacResult, ExtCtxt, DummyResult, MacEager};
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token::{self, InternedString};
@@ -28,7 +27,7 @@ pub fn expand_cpp_include<'a>(ec: &'a mut ExtCtxt,
         expn_id: mac_span.expn_id,
     };
 
-    let inner = ec.parse_sess.span_diagnostic.cm.span_to_snippet(span).unwrap();
+    let inner = ec.parse_sess.codemap().span_to_snippet(span).unwrap();
 
     let mut headers = CPP_HEADERS.lock().unwrap();
     *headers = format!("{}\n#include {}\n", *headers, inner);
@@ -51,7 +50,7 @@ pub fn expand_cpp_header<'a>(ec: &'a mut ExtCtxt,
         expn_id: mac_span.expn_id,
     };
 
-    let inner = ec.parse_sess.span_diagnostic.cm.span_to_snippet(span).unwrap();
+    let inner = ec.parse_sess.codemap().span_to_snippet(span).unwrap();
 
     let mut headers = CPP_HEADERS.lock().unwrap();
     *headers = format!("{}\n{}\n", *headers, inner);
@@ -142,7 +141,7 @@ pub fn expand_cpp<'a>(ec: &'a mut ExtCtxt,
                 return DummyResult::expr(span);
             }
 
-            ec.parse_sess.span_diagnostic.cm.span_to_snippet(span).unwrap()
+            ec.parse_sess.codemap().span_to_snippet(span).unwrap()
         }
         _ => {
             ec.span_err(mac_span, "cpp! body must be a block surrounded by `{}`");
@@ -197,7 +196,7 @@ pub fn expand_cpp<'a>(ec: &'a mut ExtCtxt,
         items: vec![P(ForeignItem {
                         ident: fn_ident.clone(),
                         attrs: Vec::new(),
-                        node: ForeignItemFn(ec.fn_decl(params, ret_ty), empty_generics()),
+                        node: ForeignItemFn(ec.fn_decl(params, ret_ty), Generics::default()),
                         id: DUMMY_NODE_ID,
                         span: mac_span,
                         vis: Inherited,

--- a/src/types.rs
+++ b/src/types.rs
@@ -134,13 +134,13 @@ impl TypeName {
                         cx.lint(BAD_CXX_TYPE, &warn.msg);
                     }
 
-                    cx.sess().note("C++ code will recieve an opaque reference");
+                    cx.sess().note_without_error("C++ code will recieve an opaque reference");
 
                     for note in &warn.notes {
                         if let Some(span) = note.span {
-                            cx.sess().span_note(span, &note.msg);
+                            cx.sess().span_note_without_error(span, &note.msg);
                         } else {
-                            cx.sess().note(&note.msg);
+                            cx.sess().note_without_error(&note.msg);
                         }
                     }
                 }
@@ -154,13 +154,13 @@ impl TypeName {
                 }
 
                 cx.sess()
-                  .note("This type can't be passed by value, and thus is an invalid return type");
+                  .note_without_error("This type can't be passed by value, and thus is an invalid return type");
 
                 for note in &err.notes {
                     if let Some(span) = note.span {
-                        cx.sess().span_note(span, &note.msg);
+                        cx.sess().span_note_without_error(span, &note.msg);
                     } else {
-                        cx.sess().note(&note.msg);
+                        cx.sess().note_without_error(&note.msg);
                     }
                 }
             }


### PR DESCRIPTION
This PR:
* Updates this to compile with nightly 1.7.0
* Bumps the version to 0.0.13 in Cargo.toml
* Gives a small sample in the README to show how to use this plugin