### PR TITLE
Update lib.rs documentation

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -55,7 +55,7 @@
 //! cpp = "0.2"
 //! cpp_macros = "0.2"
 //!
-//! [dev-dependencies]
+//! [build-dependencies]
 //! cpp_build = "0.2"
 //! ```
 //!


### PR DESCRIPTION
changed [dev-dependencies] to [build-dependencies].

[dev-dependencies] are only available at `cargo test` but not at `cargo build`

[dependencies](http://doc.crates.io/specifying-dependencies.html#development-dependencies)