### PR TITLE
Correct placement of 'const' relative to '&' in C++ code

### DIFF
--- a/cpp_build/src/lib.rs
+++ b/cpp_build/src/lib.rs
@@ -109,7 +109,7 @@ fn gen_cpp_lib(visitor: &Handle) -> PathBuf {
                    }| if mutable {
                      format!("{} & {}", cpp, name)
                  } else {
-                     format!("const {} & {}", cpp, name)
+                     format!("{} const& {}", cpp, name)
                  })
             .collect::<Vec<_>>()
             .join(", ");


### PR DESCRIPTION
To see why the old behavior was incorrect, consider this case:

```rust
fn stuff(ptr: *mut Foo) {
    cpp!([ptr as "Foo*"] { cpp_stuff(ptr); });
}
```

`ptr` is a non-mutable binding containing a mutable pointer. A reference to it is of Rust type `&*mut Foo`. Currently `cpp_build` converts this to `const Foo* &` which is equivalent to Rust type `&mut *const Foo`. With this change, it converts it to `Foo* const&` which is equivalent to `&*mut Foo`.

Similar problems arise attempting to use `"const char*"` as the C++-side type for `*const c_char`, resulting in duplicate `const`.