### PR TITLE
Allow the use of the cpp! and cpp_class! macro within other macro

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -330,3 +330,10 @@ fn rust_submacro_trait() {
     })};
     assert_eq!(i, 123 + 333);
 }
+
+#[test]
+fn witin_macro() {
+    assert_eq!(unsafe { cpp!([] -> u32 as "int" { return 12; }) }, 12);
+    let s = format!("hello{}", unsafe { cpp!([] -> u32 as "int" { return 14; }) } );
+    assert_eq!(s, "hello14");
+}


### PR DESCRIPTION
The cpp! and cpp_class! macro still need to be verbatim in the source
code, and cannot be generated by the macro_rules. But if they are
present as it within other macro, cpp_build will now generate the
code for them.

https://github.com/mystor/rust-cpp/issues/19