### PR TITLE
Allow to put the unsafe keyword within the cpp! macro

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -136,7 +136,17 @@ macro_rules! __cpp_internal {
 /// ```ignore
 /// let y: i32 = 10;
 /// let mut z: i32 = 20;
-/// let x: i32 = cpp!([y as "int32_t", mut z as "int32_t"] -> i32 as "int32_t" {
+/// let x: i32 = unsafe { cpp!([y as "int32_t", mut z as "int32_t"] -> i32 as "int32_t" {
+///     z++;
+///     return y + z;
+/// })};
+/// ```
+///
+/// You can also put the unsafe keyword as the first keyword of the cpp! macro, which
+/// has the same effect as putting the whole macro in an unsafe block:
+///
+/// ```ignore
+/// let x: i32 = cpp!(unsafe [y as "int32_t", mut z as "int32_t"] -> i32 as "int32_t" {
 ///     z++;
 ///     return y + z;
 /// });
@@ -190,6 +200,9 @@ macro_rules! cpp {
             __cpp_closure_impl![$($captures)*]
         }
     };
+
+    // wrap unsafe
+    (unsafe $($tail:tt)*) => { unsafe { cpp!($($tail)*) } };
 }
 
 #[doc(hidden)]

--- a/cpp_common/src/lib.rs
+++ b/cpp_common/src/lib.rs
@@ -174,7 +174,8 @@ pub mod parsing {
            ));
 
     named!(pub cpp_closure -> Closure,
-           do_parse!(captures: captures >>
+           do_parse!(option!(keyword!("unsafe")) >>
+                     captures: captures >>
                      ret: ret_ty >>
                      code: code_block >>
                      (Closure {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -337,3 +337,9 @@ fn witin_macro() {
     let s = format!("hello{}", unsafe { cpp!([] -> u32 as "int" { return 14; }) } );
     assert_eq!(s, "hello14");
 }
+
+#[test]
+fn with_unsafe() {
+    let x = 45;
+    assert_eq!(cpp!(unsafe [x as "int"] -> u32 as "int" { return x + 1; }), 46);
+}


### PR DESCRIPTION
Having to put an unsafe keyword around the cpp! closure mean
also adding a level of {} nesting which is annoying for the
readability.
So this allow to put the unsafe keyword directly within the
macro without forcing another level of nesting.