### PR TITLE
Improve docs.

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -63,8 +63,8 @@ extern crate cpp_macros;
 #[doc(hidden)]
 pub use cpp_macros::*;
 
-/// Internal macro which is used to locate the rust! invocations in the
-/// C++ code embbeded in cpp! invocation, to translate them into extern
+/// Internal macro which is used to locate the `rust!` invocations in the
+/// C++ code embedded in `cpp!` invocation, to translate them into `extern`
 /// functions
 #[doc(hidden)]
 #[macro_export]
@@ -126,7 +126,7 @@ macro_rules! __cpp_internal {
 /// }}
 /// ```
 ///
-/// The second variant is used to embed C++ code within rust code. A list of
+/// The second variant is used to embed C++ code within Rust code. A list of
 /// variable names which should be captured are taken as the first argument,
 /// with their corresponding C++ type. The body is compiled as a C++ function.
 ///
@@ -142,8 +142,8 @@ macro_rules! __cpp_internal {
 /// })};
 /// ```
 ///
-/// You can also put the unsafe keyword as the first keyword of the cpp! macro, which
-/// has the same effect as putting the whole macro in an unsafe block:
+/// You can also put the unsafe keyword as the first keyword of the `cpp!` macro, which
+/// has the same effect as putting the whole macro in an `unsafe` block:
 ///
 /// ```ignore
 /// let x: i32 = cpp!(unsafe [y as "int32_t", mut z as "int32_t"] -> i32 as "int32_t" {
@@ -154,8 +154,8 @@ macro_rules! __cpp_internal {
 ///
 /// ## rust! pseudo-macro
 ///
-/// The cpp! macro can contain, in the C++ code, a rust! sub-macro, which allows
-/// to include rust code in C++ code. This is useful to
+/// The `cpp!` macro can contain, in the C++ code, a `rust!` sub-macro, which allows
+/// the inclusion of Rust code in C++ code. This is useful to
 /// implement callback or override virtual functions. Example:
 ///
 /// ```ignore
@@ -178,12 +178,12 @@ macro_rules! __cpp_internal {
 /// }}
 /// ```
 ///
-/// The syntax for the rust! macro is:
+/// The syntax for the `rust!` macro is:
 /// ```ignore
 /// rust!($uniq_ident:ident [$($arg_name:ident : $arg_rust_type:ty as $arg_c_type:tt),*]
 ///      $(-> $ret_rust_type:ty as $rust_c_type:tt)* {$($body:tt)*})
 /// ```
-/// uniq_ident is an unique identifier which will be used to name the extern function
+/// `uniq_ident` is a unique identifier which will be used to name the `extern` function
 #[macro_export]
 macro_rules! cpp {
     // raw text inclusion
@@ -213,8 +213,8 @@ pub trait CppTrait {
     const CPP_TYPE: &'static str;
 }
 
-/// This macro allow to wrap a relocatable C++ struct or class that might have
-/// destructor or copy constructor, instantiating the Drop and Clone trait
+/// This macro allows wrapping a relocatable C++ struct or class that might have
+/// a destructor or copy constructor, implementing the `Drop` and `Clone` trait
 /// appropriately.
 ///
 /// ```ignore
@@ -231,8 +231,8 @@ pub trait CppTrait {
 /// }
 /// ```
 ///
-/// This will create a rust struct MyClass, which has the same size and
-/// alignment as the the C++ class "MyClass". It will also implement the `Drop` trait
+/// This will create a Rust struct `MyClass`, which has the same size and
+/// alignment as the C++ class `MyClass`. It will also implement the `Drop` trait
 /// calling the destructor, the `Clone` trait calling the copy constructor, if the
 /// class is copyable (or `Copy` if it is trivially copyable), and `Default` if the class
 /// is default constructible
@@ -250,7 +250,7 @@ pub trait CppTrait {
 /// * The trait `PartialOrd` need the C++ `operator<` for that type. `lt`, `le`, `gt` and
 ///   `ge` will use the corresponding C++ operator if it is defined, otherwise it will
 ///   fallback to the less than operator. For PartialOrd::partial_cmp, the `operator<` will
-///   be called twice. Note that it will never return None.
+///   be called twice. Note that it will never return `None`.
 /// * The trait `Ord` can also be specified when the semantics of the `operator<` corresponds
 ///   to a total order
 ///
@@ -265,11 +265,11 @@ pub trait CppTrait {
 ///
 /// Unfortunately, as the STL often uses internal self-references for
 /// optimization purposes, such as the small-string optimization, this disallows
-/// most std:: classes. This restriction exists because safe rust is allowed to
+/// most std:: classes. This restriction exists because safe Rust is allowed to
 /// move your types around.
 ///
 /// Most C++ types which do not contain self-references will be compatible,
-/// although this property cannot be statically checked by rust-cpp.
+/// although this property cannot be statically checked by `rust-cpp`.
 ///
 #[macro_export]
 macro_rules! cpp_class {

--- a/cpp_build/src/lib.rs
+++ b/cpp_build/src/lib.rs
@@ -57,7 +57,7 @@ const INTERNAL_CPP_STRUCTS: &'static str = add_line!(r#"
 namespace rustcpp {
 
 // We can't just pass or return any type from extern "C" rust functions (because the call
-// convention may differ between the C++ type, and the rust type).
+// convention may differ between the C++ type, and the Rust type).
 // So we make sure to pass trivial structure that only contains a pointer to the object we want to
 // pass. The constructor of these helper class contains a 'container' of the right size which will
 // be allocated on the stack.

--- a/cpp_common/src/lib.rs
+++ b/cpp_common/src/lib.rs
@@ -34,7 +34,7 @@ pub mod kw {
 }
 
 /// This constant is expected to be a unique string within the compiled binary
-/// which preceeds a definition of the metadata. It begins with
+/// which precedes a definition of the metadata. It begins with
 /// rustcpp~metadata, which is printable to make it easier to locate when
 /// looking at a binary dump of the metadata.
 ///
@@ -76,7 +76,7 @@ pub struct Capture {
 }
 
 impl Parse for Capture {
-    /// Parse a single captured variable inside within a cpp! macro.
+    /// Parse a single captured variable inside within a `cpp!` macro.
     /// Example: `mut foo as "int"`
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Capture {
@@ -118,12 +118,12 @@ impl ClosureSig {
 pub struct Closure {
     pub sig: ClosureSig,
     pub body: TokenTree,
-    pub body_str: String, // with rust! macro replaced
+    pub body_str: String, // with `rust!` macro replaced
     pub callback_offset: u32,
 }
 
 impl Parse for Closure {
-    /// Parse the inside of a cpp! macro when this macro is a closure.
+    /// Parse the inside of a `cpp!` macro when this macro is a closure.
     /// Example: `unsafe [foo as "int"] -> u32 as "int" { /*... */ }
     fn parse(input: ParseStream) -> Result<Self> {
         input.parse::<Option<Token![unsafe]>>()?;
@@ -207,7 +207,7 @@ impl Class {
 }
 
 impl Parse for Class {
-    /// Parse the inside of a cpp_class! macro.
+    /// Parse the inside of a `cpp_class!` macro.
     /// Example: `#[derive(Default)] pub unsafe struct Foobar as "FooBar"`
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Class {
@@ -234,7 +234,7 @@ pub enum Macro {
 }
 
 impl Parse for Macro {
-    ///! Parse the inside of a cpp! macro (a literal or a closure)
+    ///! Parse the inside of a `cpp!` macro (a literal or a closure)
     fn parse(input: ParseStream) -> Result<Self> {
         if input.peek(syn::token::Brace) {
             let content;
@@ -255,7 +255,7 @@ pub struct RustInvocation {
 }
 
 impl Parse for RustInvocation {
-    /// Parse a rust! macro something looking like `rust!(ident [foo : bar as "bar"] { /*...*/ })`
+    /// Parse a `rust!` macro something looking like `rust!(ident [foo : bar as "bar"] { /*...*/ })`
     fn parse(input: ParseStream) -> Result<Self> {
         let rust_token = input.parse::<kw::rust>()?;
         input.parse::<Token![!]>()?;

--- a/cpp_macros/src/lib.rs
+++ b/cpp_macros/src/lib.rs
@@ -117,8 +117,8 @@ Version mismatch between cpp_macros and cpp_build for same crate."#
 }
 
 /// Try to open a file handle to the lib file. This is used to scan it for
-/// metadata. We check both MSVC_LIB_NAME and LIB_NAME, in case we are on
-/// or are targeting windows.
+/// metadata. We check both `MSVC_LIB_NAME` and `LIB_NAME`, in case we are on
+/// or are targeting Windows.
 fn open_lib_file() -> io::Result<File> {
     if let Ok(file) = File::open(OUT_DIR.join(MSVC_LIB_NAME)) {
         Ok(file)
@@ -155,7 +155,7 @@ fn find_all_rust_macro(
     return Ok(r);
 }
 
-/// Find the occurence of the strignify! macro within the macro derive
+/// Find the occurrence of the `stringify!` macro within the macro derive
 fn extract_original_macro(input: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
     #[derive(Default)]
     struct Finder(Option<proc_macro2::TokenStream>);


### PR DESCRIPTION
This fixes some typos, uses backticks around some identifiers,
fixes capitalization of Rust and Windows, and improves upon some
grammar.