### PR TITLE
mute clippy lint properly

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -86,8 +86,8 @@ macro_rules! __cpp_internal {
     (@expand_rust_macro [$($a:tt)*] $i:ident [$($an:ident : $at:ty as $ac:tt),*] {$($body:tt)*}) => {
         #[allow(non_snake_case)]
         #[allow(unused_unsafe)]
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_ref))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_ref))]
         #[doc(hidden)]
         $($a)* unsafe extern "C" fn $i($($an : *const $at),*) {
             $(let $an : $at = unsafe { $an.read() };)*
@@ -99,8 +99,8 @@ macro_rules! __cpp_internal {
     (@expand_rust_macro [$($a:tt)*] $i:ident [$($an:ident : $at:ty as $ac:tt),*] -> $rt:ty as $rc:tt {$($body:tt)*}) => {
         #[allow(non_snake_case)]
         #[allow(unused_unsafe)]
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_ref))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_ref))]
         #[doc(hidden)]
         $($a)* unsafe extern "C" fn $i($($an : *const $at, )* rt : *mut $rt) -> *mut $rt {
 


### PR DESCRIPTION
I noticed that clippy showed errors inside of the `cpp!` macro.

There was code in place already to mute those errors, but apparently the format of the attribute changed over the last few months (??).

This change makes the errors disappear for me.