### PR TITLE
Fix multiple definition error on windows

### DIFF
--- a/cpp_build/src/lib.rs
+++ b/cpp_build/src/lib.rs
@@ -345,7 +345,9 @@ struct MetaData {{
 }};
 
 MetaData
-#ifdef __GNUC__
+#ifdef _WIN64
+    __declspec (selectany)
+#elif __GNUC__
     __attribute__((weak))
 #endif
     metadata = {{


### PR DESCRIPTION
According to https://gcc.gnu.org/onlinedocs/gcc-4.4.6/gcc/Variable-Attributes.html, selectany can be used for windows.
Fixes https://github.com/mystor/rust-cpp/issues/53