### PR TITLE
_WIN32 is better for windows detection

### DIFF
--- a/cpp_build/src/lib.rs
+++ b/cpp_build/src/lib.rs
@@ -345,7 +345,7 @@ struct MetaData {{
 }};
 
 MetaData
-#ifdef _WIN64
+#ifdef _WIN32
     __declspec (selectany)
 #elif __GNUC__
     __attribute__((weak))


### PR DESCRIPTION
via https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
_WIN32 Defined as 1 when the compilation target is 32-bit ARM, 64-bit ARM, x86, or x64. Otherwise, undefined.
_WIN64 Defined as 1 when the compilation target is 64-bit ARM or x64. Otherwise, undefined.