### PR TITLE
Add support for parsing simple #[cfg(feature = "feature")] to allow conditional module inclusion

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -56,6 +56,18 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Limitations
+//!
+//! As with all procedure macro crates we also need to parse Rust source files to
+//! extract C++ code. That leads to the fact that some of the language features
+//! might not be supported in full. One example is the attributes. Only a limited
+//! number of attributes is supported, namely: `#[path = "..."]` for `mod`
+//! declarations to specify an alternative path to the module file and
+//! `#[cfg(feature = "...")]` for `mod` declarations to conditionally include the
+//! module into the parsing process. Please note that the latter is only supported
+//! in its simplest form: straight-forward `feature = "..."` without any
+//! additional conditions, `cfg!` macros are also not supported at the moment.
 
 #[macro_use]
 #[allow(unused_imports)]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -13,6 +13,10 @@ mod nomod {
     pub mod inner;
 }
 
+// This non-existent module should not be parsed
+#[cfg(feature = "non_existent")]
+mod non_existent;
+
 fn add_two(x: i32) -> i32 {
     x + 2
 }


### PR DESCRIPTION
Only simple straight-forward #[cfg]'s with only "feature" are supported, no complex conditions are allowed