### PR TITLE
cpp crate doc example: rename lib.rs to main.rs

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -9,7 +9,7 @@
 //! crate
 //! |-- Cargo.toml
 //! |-- src
-//!     |-- lib.rs
+//!     |-- main.rs
 //! |-- build.rs
 //! ```
 //!
@@ -34,11 +34,11 @@
 //! extern crate cpp_build;
 //!
 //! fn main() {
-//!     cpp_build::build("src/lib.rs");
+//!     cpp_build::build("src/main.rs");
 //! }
 //! ```
 //!
-//! #### lib.rs
+//! #### main.rs
 //!
 //! ```ignore
 //! # // tested in test/src/examples.rs


### PR DESCRIPTION
I think it makes more sense for the first example to list the contents of `main.rs` rather than `lib.rs`, given that it contains a runnable `main` function.