### PR TITLE
Clean up clippy warnings

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_doctest_main)]
 //! This crate `cpp` provides macros that allow embedding arbitrary C++ code.
 //!
 //! # Usage
@@ -32,7 +33,6 @@
 //!
 //! ```no_run
 //! extern crate cpp_build;
-//!
 //! fn main() {
 //!     cpp_build::build("src/main.rs");
 //! }

--- a/cpp_build/src/parser.rs
+++ b/cpp_build/src/parser.rs
@@ -5,7 +5,6 @@ use std::fs::File;
 use std::io::Read;
 use std::mem::swap;
 use std::path::PathBuf;
-use syn;
 use syn::visit::Visit;
 
 #[derive(Debug)]

--- a/cpp_build/src/parser.rs
+++ b/cpp_build/src/parser.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::Read;
 use std::mem::swap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use syn::visit::Visit;
 
 #[derive(Debug)]
@@ -334,7 +334,7 @@ fn test_cursor_advance() -> Result<(), LexError> {
     Ok(())
 }
 
-fn line_directive(path: &PathBuf, cur: Cursor) -> String {
+fn line_directive(path: &Path, cur: Cursor) -> String {
     let mut line = format!(
         "#line {} \"{}\"\n",
         cur.line + 1,

--- a/cpp_build/src/strnom.rs
+++ b/cpp_build/src/strnom.rs
@@ -22,6 +22,7 @@ pub struct Cursor<'a> {
 }
 
 impl<'a> Cursor<'a> {
+    #[allow(clippy::suspicious_map)]
     pub fn advance(&self, amt: usize) -> Cursor<'a> {
         let mut column_start: Option<usize> = None;
         Cursor {
@@ -31,7 +32,7 @@ impl<'a> Cursor<'a> {
                 + self.rest[..amt]
                     .char_indices()
                     .filter(|&(_, ref x)| *x == '\n')
-                    .map(|(i, _)| column_start = Some(i))
+                    .map(|(i, _)| { column_start = Some(i); } )
                     .count() as u32,
             column: match column_start {
                 None => self.column + (amt as u32),

--- a/cpp_build/src/strnom.rs
+++ b/cpp_build/src/strnom.rs
@@ -171,18 +171,18 @@ fn is_whitespace(ch: char) -> bool {
 
 #[inline]
 fn is_ident_start(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
+    ('a'..='z').contains(&c)
+        || ('A'..='Z').contains(&c)
         || c == '_'
         || (c > '\x7f' && UnicodeXID::is_xid_start(c))
 }
 
 #[inline]
 fn is_ident_continue(c: char) -> bool {
-    ('a' <= c && c <= 'z')
-        || ('A' <= c && c <= 'Z')
+    ('a'..='z').contains(&c)
+        || ('A'..='Z').contains(&c)
         || c == '_'
-        || ('0' <= c && c <= '9')
+        || ('0'..='9').contains(&c)
         || (c > '\x7f' && UnicodeXID::is_xid_continue(c))
 }
 

--- a/cpp_build/src/strnom.rs
+++ b/cpp_build/src/strnom.rs
@@ -171,18 +171,15 @@ fn is_whitespace(ch: char) -> bool {
 
 #[inline]
 fn is_ident_start(c: char) -> bool {
-    ('a'..='z').contains(&c)
-        || ('A'..='Z').contains(&c)
+    c.is_ascii_alphabetic()
         || c == '_'
         || (c > '\x7f' && UnicodeXID::is_xid_start(c))
 }
 
 #[inline]
 fn is_ident_continue(c: char) -> bool {
-    ('a'..='z').contains(&c)
-        || ('A'..='Z').contains(&c)
+    c.is_ascii_alphanumeric()
         || c == '_'
-        || ('0'..='9').contains(&c)
         || (c > '\x7f' && UnicodeXID::is_xid_continue(c))
 }
 

--- a/cpp_macros/src/lib.rs
+++ b/cpp_macros/src/lib.rs
@@ -184,6 +184,7 @@ fn extract_original_macro(input: &syn::DeriveInput) -> Option<proc_macro2::Token
 }
 
 #[proc_macro_derive(__cpp_internal_closure)]
+#[allow(clippy::cognitive_complexity)]
 pub fn expand_internal(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     assert_eq!(
         env!("CARGO_PKG_VERSION"),

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -51,6 +51,14 @@ cpp! {{
             ptr
         });
     }
+    int callRustExplicitReturn(int x) {
+        return rust!(explicitReturnCallback [x : i32 as "int"] -> i32 as "int" {
+            if x == 0 {
+                return 42;
+            }
+            x + 1
+        });
+    }
 }}
 
 cpp_class!(
@@ -241,6 +249,11 @@ fn rust_submacro() {
         assert_eq!(result, true);
     }
     assert_eq!(val, 21); // callRust2 does +=3
+
+    let result = unsafe { cpp!([] -> i32 as "int" { return callRustExplicitReturn(0); }) };
+    assert_eq!(result, 42);
+    let result = unsafe { cpp!([] -> i32 as "int" { return callRustExplicitReturn(9); }) };
+    assert_eq!(result, 10);
 
     let result = unsafe {
         cpp!([]->bool as "bool" {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -46,8 +46,10 @@ cpp! {{
         typedef int LocalInt;
         typedef void * VoidStar;
         return rust!(ptrCallback [ptr : *mut u32 as "void*", a : u32 as "LocalInt"]
-            -> *mut u32 as "VoidStar"
-        { unsafe {*ptr += a}; return ptr; });
+                -> *mut u32 as "VoidStar" {
+            unsafe {*ptr += a};
+            ptr
+        });
     }
 }}
 
@@ -112,13 +114,13 @@ cpp! {{
         double fval = 5.5;
         double res = rust!(xx___8 [fval : f64 as "double"] -> f64 as "double" { fval * 1.2 + 9.9 } );
         if (int((res - (5.5 * 1.2 + 9.9)) * 100000) != 0) return 5;
-        res = rust!(xx___9 [fval : &mut f64 as "double&"] -> f64 as "double" { *fval = *fval * 2.2; 8.8 } );
+        res = rust!(xx___9 [fval : &mut f64 as "double&"] -> f64 as "double" { *fval *= 2.2; 8.8 } );
         if (int((res - (8.8)) * 100000) != 0) return 9;
         if (int((fval - (5.5 * 2.2)) * 100000) != 0) return 10;
         // with a class
         A a(3,4);
         rust!(xx___10 [a : A as "A"] { let a2 = a.clone(); assert!(a2.multiply() == 12); } );
-        rust!(xx___11 [a : A as "A"] { let _a = a.clone(); return; } );
+        rust!(xx___11 [a : A as "A"] { let _a = a.clone(); } );
         return 0;
     }
 }}


### PR DESCRIPTION
Supersedes #81.

Now `cargo clippy` produces no warnings at all. I had to `#[allow]` that `suspicious_map` though, because there seems to be no pretty workaround.