### PR TITLE
chore: Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ the [`cpp` crate module level documentation](https://docs.rs/cpp).
 
 ## Differences with the [`cxx`](https://cxx.rs) crate
 
-This crate allows to write C++ code "inline" within yout Rust functions, while with the [`cxx`](https://cxx.rs) crate, you have
+This crate allows to write C++ code "inline" within your Rust functions, while with the [`cxx`](https://cxx.rs) crate, you have
 to write a bit of boiler plate to have calls to functions declared in a different `.cpp` file.
-Having C++ code inline might be helpful when trying to call to a C++ library and that one may whish to make plenty of call to small snipets.
+
+Having C++ code inline might be helpful when trying to call to a C++ library and that one may wish to make plenty of call to small snippets.
 It can otherwise be fastidious to write and maintain the boiler plate for many small functions in different places. 
 
-These crate can also be used in together. The `cxx` crate offer some usefull types such as `CxxString` that can also be used wth this crate.
+These crate can also be used in together. The `cxx` crate offer some useful types such as `CxxString` that can also be used with this crate.
 
-The `cxx` bridge does more type checking which can avoid some classes of errors. While this crate can only check for equal size and alignement.
+The `cxx` bridge does more type checking which can avoid some classes of errors. While this crate can only check for equal size and alignment.

--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -336,7 +336,7 @@ pub trait CppTrait {
 /// Most C++ types which do not contain self-references will be compatible,
 /// although this property cannot be statically checked by `rust-cpp`.
 /// All types that satisfy `std::is_trivially_copyable` are compatible.
-/// Maybe future version of the C++ standard would allow a comile-time check:
+/// Maybe future version of the C++ standard would allow a compile-time check:
 /// [P1144](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1144r4.html)
 ///
 /// Unfortunately, as the STL often uses internal self-references for


### PR DESCRIPTION
Just typo fixes, mostly in the README.md