### PR TITLE
cpp_build: disable LTO to preserve metadata in .data section

### DIFF
--- a/cpp_build/src/lib.rs
+++ b/cpp_build/src/lib.rs
@@ -654,6 +654,15 @@ In order to provide a better error message, the build script will exit successfu
         if !self.std_flag_set {
             self.cc.flag_if_supported("-std=c++11");
         }
+        // Disable LTO for the generated C++ library. The cpp crate embeds
+        // metadata as raw bytes in the .data section of the compiled object,
+        // which the cpp_macros proc-macro later locates via byte pattern
+        // matching. When LTO is enabled (e.g. -flto=auto from environment
+        // CXXFLAGS), the compiler emits GIMPLE IR instead of native code,
+        // leaving the .data section empty and making the metadata invisible
+        // to the proc-macro.
+        self.cc.flag_if_supported("-fno-lto");
+
         // Build the C++ library
         if let Err(e) = self.cc.file(filename).try_compile(LIB_NAME) {
             let _ = writeln!(std::io::stderr(), "\n\nerror occurred: {}\n\n", e);


### PR DESCRIPTION
## Summary

- Fix proc-macro panic "Struct metadata not present in target library file" when building with LTO enabled

## Problem

The `cpp` crate communicates type metadata (sizes, alignments, trait flags) from `cpp_build` to `cpp_macros` by embedding a struct with a magic byte pattern in the `.data` section of the compiled static library. The proc-macro scans the `.a` file for this pattern using `aho_corasick`.

When LTO is enabled via environment `CXXFLAGS` (e.g. `-flto=auto`), the C++ compiler emits GIMPLE intermediate representation instead of native machine code. The `.data` section is empty — all content lives in `.gnu.lto_*` sections. The magic bytes become invisible to the byte-level scan, causing the proc-macro to panic:

```
-- rust-cpp fatal error --

Struct metadata not present in target library file.
NOTE: Double-check that the version of cpp_build and cpp_macros match
```

This affects distributions that enable LTO by default in their build systems:
- **Arch Linux** (`makepkg` sets `-flto=auto` via `CXXFLAGS`)
- **Fedora** (LTO enabled by default since F33)
- **Gentoo** (with LTO profiles)

Currently broken downstream packages include **LibrePCB** (via `qttypes`/Slint) and anything else using the `cpp` crate.

## Fix

Pass `-fno-lto` when compiling the generated C++ library, ensuring the metadata struct is always present as raw bytes in `.data` regardless of environment LTO settings.

## Test plan

- [x] Verified that LibrePCB builds successfully on Arch Linux with this fix (previously failed with 697 errors from qttypes proc-macro panics)
- [ ] Existing tests should continue to pass since `-fno-lto` only affects the small generated metadata library, not the final binary linkage